### PR TITLE
Upgrade to bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ documentation = "https://docs.rs/bevy_iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.9"
-bevy_derive = "0.9"
-bevy_ecs = "0.9"
-bevy_input = "0.9"
-bevy_render = "0.9"
-bevy_utils = "0.9"
-bevy_window = "0.9"
+bevy_app = "0.10"
+bevy_derive = "0.10"
+bevy_ecs = "0.10"
+bevy_input = "0.10"
+bevy_render = "0.10"
+bevy_utils = "0.10"
+bevy_window = "0.10"
 
-iced_wgpu = "0.7"
-iced_native = "0.7"
+iced_wgpu = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_wgpu" }
+iced_native = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_native" }
 
 [dev-dependencies]
-bevy = "0.9"
+bevy = "0.10"
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,18 @@ impl Plugin for IcedPlugin {
     }
 }
 
+#[derive(PartialEq)]
+enum DidDraw {
+    No,
+    LastFrame,
+    Yes,
+}
+
 struct IcedProps {
     renderer: iced_wgpu::Renderer,
     debug: iced_native::Debug,
     clipboard: iced_native::clipboard::Null,
-    did_draw: bool,
+    did_draw: DidDraw,
 }
 
 impl IcedProps {
@@ -109,7 +116,7 @@ impl IcedProps {
             )),
             debug: Debug::new(),
             clipboard: iced_native::clipboard::Null,
-            did_draw: false,
+            did_draw: DidDraw::No,
         }
     }
 }
@@ -260,6 +267,6 @@ impl<'w, 's, M: Event> IcedContext<'w, 's, M> {
 
         self.events.clear();
         *cache_entry = Some(ui.into_cache());
-        *did_draw = true;
+        *did_draw = DidDraw::Yes;
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -13,7 +13,7 @@ use bevy_ecs::prelude::Query;
 use bevy_render::renderer::RenderDevice;
 use bevy_window::Window;
 
-use crate::{IcedProps, IcedResource, IcedSettings};
+use crate::{DidDraw, IcedProps, IcedResource, IcedSettings};
 
 pub const ICED_PASS: &'static str = "bevy_iced_pass";
 
@@ -76,8 +76,14 @@ impl Node for IcedNode {
         } = &mut *world.resource::<IcedResource>().lock().unwrap();
         let render_device = world.resource::<RenderDevice>();
 
-        if !*did_draw {
+        if *did_draw == DidDraw::No {
             return Ok(());
+        }
+
+        match *did_draw {
+            DidDraw::No => return Ok(()),
+            DidDraw::LastFrame => *did_draw = DidDraw::No,
+            DidDraw::Yes => *did_draw = DidDraw::LastFrame,
         }
 
         let view = extracted_window.swap_chain_texture.as_ref().unwrap();
@@ -99,7 +105,6 @@ impl Node for IcedNode {
         });
 
         staging_belt.finish();
-        *did_draw = false;
 
         Ok(())
     }


### PR DESCRIPTION
This is what I've done as a follow-up on https://github.com/tasgon/bevy_iced/issues/4

So, I've upgraded iced's wgpu in a fork:
https://github.com/kulkalkul/iced/commits/self-usage
I've done it, so it is non-breaking. Those expect calls there are similar in how it handles pre-wgpu 0.14. It is also handled the same in
https://github.com/sconybeare/wgpu_glyph/tree/wgpu-0.15

For bevy_iced, there are two changes I think you might be interested in:
- I've changed Res\<Windows\> to Query\<Window\> and kept it a single window (I have no idea how I can do it for multiple windows).
- Bevy decided to hide RenderContext fields, so they can only be accessed with functions (https://github.com/bevyengine/bevy/pull/7248). But the command_encoder function is &mut self, so it isn't possible to get both device and command_encoder from RenderContext. So, I've got the RenderDevice from the world, which is OK but feels a little hacky tbh.

Aside from the above points, a bug causes flashing rendering for UI. It happens randomly, at a random rate, sometimes so slow it is unnoticeable. Here is the video of it:

# **FAST FLICKERING VIDEO, EPILEPSY/SEIZURE WARNING!**

https://user-images.githubusercontent.com/1013994/227149053-fc5ba1d4-7bf5-4298-b957-a340e2630368.mp4

---
I've figured that the new pipelined rendering implementation causes ``IcedNode::run`` to run parallel to ``IcedContext::display``. As a result, the run function misses the ``IcedProp.did_draw`` change. I didn't know the project enough to solve it, so I decided to ask it.

I hope this isn't too long 😅