### PR TITLE
Upgrade to bevy 0.10 (alternate method)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_iced"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Iced integration for Bevy"
 authors = ["tasgon <tasgon_@outlook.com>"]
@@ -21,8 +21,8 @@ bevy_render = "0.10"
 bevy_utils = "0.10"
 bevy_window = "0.10"
 
-iced_wgpu = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_wgpu" }
-iced_native = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_native" }
+iced_wgpu = "0.10"
+iced_native = "0.10"
 
 [dev-dependencies]
 bevy = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ documentation = "https://docs.rs/bevy_iced"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = "0.9"
-bevy_derive = "0.9"
-bevy_ecs = "0.9"
-bevy_input = "0.9"
-bevy_render = "0.9"
-bevy_utils = "0.9"
-bevy_window = "0.9"
+bevy_app = "0.10"
+bevy_derive = "0.10"
+bevy_ecs = "0.10"
+bevy_input = "0.10"
+bevy_render = "0.10"
+bevy_utils = "0.10"
+bevy_window = "0.10"
 
-iced_wgpu = "0.7"
-iced_native = "0.7"
+iced_wgpu = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_wgpu" }
+iced_native = { git = "https://github.com/kulkalkul/iced.git", branch = "self-usage", package = "iced_native" }
 
 [dev-dependencies]
-bevy = "0.9"
+bevy = "0.10"
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ use bevy::prelude::*;
 use bevy_iced::iced::widget::text;
 use bevy_iced::{IcedContext, IcedPlugin};
 
-#[derive(Debug)]
 pub enum UiMessage {}
 
 pub fn main() {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ See the [examples](https://github.com/tasgon/bevy_iced/tree/master/examples) and
 
 |Bevy Version  |Crate Version  |
 |--------------|---------------|
-|`0.9`         |`0.2`, `master`|
+|`0.10`        |`0.3`, `master`|
+|`0.9`         |`0.2`          |
 |`0.7`         |`0.1`          |
 
 ## Todo

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,6 @@ use bevy::prelude::*;
 use bevy_iced::iced::widget::text;
 use bevy_iced::{IcedContext, IcedPlugin};
 
-#[derive(Debug)]
 pub enum UiMessage {}
 
 pub fn main() {

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -9,7 +9,7 @@ use bevy_iced::{
 };
 use rand::random as rng;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 enum UiMessage {
     BoxRequested,
     Scale(f32),

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -28,10 +28,10 @@ pub struct UiData {
 pub fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
-            window: WindowDescriptor {
+            primary_window: Some(Window {
                 present_mode: bevy_window::PresentMode::AutoNoVsync,
                 ..Default::default()
-            },
+            }),
             ..Default::default()
         }))
         .add_plugin(IcedPlugin)

--- a/examples/interactive.rs
+++ b/examples/interactive.rs
@@ -144,7 +144,7 @@ fn ui_system(
             sprites.iter().len(),
             data.scale
         )));
-    let edit = text_input("", &data.text, UiMessage::Text);
+    let edit = text_input("", &data.text).on_input(UiMessage::Text);
     let column = Column::new()
         .align_items(iced_native::Alignment::Center)
         .spacing(10)

--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+use bevy_iced::iced::widget::text;
+use bevy_iced::{IcedContext, IcedPlugin};
+use bevy_input::keyboard::KeyboardInput;
+use bevy_input::ButtonState;
+
+#[derive(Debug)]
+pub enum UiMessage {}
+
+#[derive(Resource, PartialEq, Eq)]
+pub struct UiActive(bool);
+
+pub fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(IcedPlugin)
+        .add_event::<UiMessage>()
+        .insert_resource(UiActive(true))
+        .add_system(toggle_system)
+        .add_system(ui_system.run_if(resource_equals(UiActive(true))))
+        .run();
+}
+
+fn toggle_system(mut keyboard: EventReader<KeyboardInput>, mut active: ResMut<UiActive>) {
+    for event in keyboard.iter() {
+        if event.key_code == Some(KeyCode::Space) && event.state == ButtonState::Pressed {
+            active.0 = !active.0;
+        }
+    }
+}
+
+fn ui_system(mut ctx: IcedContext<UiMessage>) {
+    ctx.display(text("Press space to toggle GUI."));
+}

--- a/examples/toggle.rs
+++ b/examples/toggle.rs
@@ -4,7 +4,6 @@ use bevy_iced::{IcedContext, IcedPlugin};
 use bevy_input::keyboard::KeyboardInput;
 use bevy_input::ButtonState;
 
-#[derive(Debug)]
 pub enum UiMessage {}
 
 #[derive(Resource, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,7 @@
 //! use bevy::prelude::*;
 //! use bevy_iced::iced::widget::text;
 //! use bevy_iced::{IcedContext, IcedPlugin};
-//!
-//! #[derive(Debug)]
+//! 
 //! pub enum UiMessage {}
 //!
 //! pub fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,13 @@ use crate::render::ViewportResource;
 use bevy_app::{App, IntoSystemAppConfig, Plugin};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::event::Event;
-use bevy_ecs::prelude::{EventWriter, Query};
+use bevy_ecs::prelude::{EventWriter, Query, With};
 use bevy_ecs::system::{NonSendMut, Res, ResMut, Resource, SystemParam};
 use bevy_render::render_graph::RenderGraph;
 use bevy_render::renderer::RenderDevice;
 use bevy_render::{ExtractSchedule, RenderApp};
 use bevy_utils::HashMap;
-use bevy_window::Window;
+use bevy_window::{Window, PrimaryWindow};
 use iced::{user_interface, Element, UserInterface};
 pub use iced_native as iced;
 use iced_native::{Debug, Size};
@@ -204,7 +204,7 @@ pub struct IcedContext<'w, 's, Message: Event> {
     viewport: Res<'w, ViewportResource>,
     props: Res<'w, IcedResource>,
     settings: Res<'w, IcedSettings>,
-    windows: Query<'w, 's, &'static Window>,
+    windows: Query<'w, 's, &'static Window, With<PrimaryWindow>>,
     events: ResMut<'w, IcedEventQueue>,
     cache_map: NonSendMut<'w, IcedCache>,
     messages: EventWriter<'w, Message>,


### PR DESCRIPTION
To deal with the desync issues in #5, this PR instead uses a `DidDraw` resource that is synced during the `Extract` phase rather than updating the state during the draw call.