### PR TITLE
Add touch events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,15 @@ documentation = "https://docs.rs/bevy_iced"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+touch = []
+
 [dependencies]
 bevy_app = "0.10"
 bevy_derive = "0.10"
 bevy_ecs = "0.10"
 bevy_input = "0.10"
+bevy_math = "0.10"
 bevy_render = "0.10"
 bevy_utils = "0.10"
 bevy_window = "0.10"

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,6 +1,15 @@
 use bevy_input::prelude::KeyCode as BevyKeyCode;
 use bevy_input::prelude::MouseButton;
+#[cfg(feature = "touch")]
+use bevy_input::touch::{TouchInput, TouchPhase};
+#[cfg(feature = "touch")]
+use bevy_math::Vec2;
 use iced_native::keyboard::KeyCode as IcedKeyCode;
+#[cfg(feature = "touch")]
+use iced_native::{
+    touch::{self, Finger},
+    Point,
+};
 
 pub fn key_code(virtual_keycode: BevyKeyCode) -> IcedKeyCode {
     match virtual_keycode {
@@ -177,5 +186,47 @@ pub fn mouse_button(button: MouseButton) -> iced_native::mouse::Button {
         MouseButton::Right => Button::Right,
         MouseButton::Middle => Button::Middle,
         MouseButton::Other(val) => Button::Other(val as u8),
+    }
+}
+
+#[cfg(feature = "touch")]
+pub fn touch_event(bevy_touch_input: &TouchInput) -> touch::Event {
+    match *bevy_touch_input {
+        TouchInput {
+            phase: TouchPhase::Started,
+            position: Vec2 { x, y },
+            id: finger,
+            ..
+        } => touch::Event::FingerPressed {
+            id: Finger(finger),
+            position: Point { x, y },
+        },
+        TouchInput {
+            phase: TouchPhase::Cancelled,
+            position: Vec2 { x, y },
+            id: finger,
+            ..
+        } => touch::Event::FingerLost {
+            id: Finger(finger),
+            position: Point { x, y },
+        },
+        TouchInput {
+            phase: TouchPhase::Ended,
+            position: Vec2 { x, y },
+            id: finger,
+            ..
+        } => touch::Event::FingerLifted {
+            id: Finger(finger),
+            position: Point { x, y },
+        },
+        TouchInput {
+            phase: TouchPhase::Moved,
+            position: Vec2 { x, y },
+            id: finger,
+            ..
+        } => touch::Event::FingerMoved {
+            id: Finger(finger),
+            position: Point { x, y },
+        },
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! use bevy::prelude::*;
 //! use bevy_iced::iced::widget::text;
 //! use bevy_iced::{IcedContext, IcedPlugin};
-//! 
+//!
 //! pub enum UiMessage {}
 //!
 //! pub fn main() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -18,7 +18,7 @@ use std::sync::Mutex;
 
 use crate::{DidDraw, IcedProps, IcedResource, IcedSettings};
 
-pub const ICED_PASS: &'static str = "bevy_iced_pass";
+pub const ICED_PASS: &str = "bevy_iced_pass";
 
 #[derive(Resource, Deref, DerefMut, Clone)]
 pub struct ViewportResource(pub Viewport);
@@ -98,7 +98,7 @@ impl Node for IcedNode {
         let view = extracted_window.swap_chain_texture.as_ref().unwrap();
         let staging_belt = &mut *self.staging_belt.lock().unwrap();
 
-        let viewport = &*world.resource::<ViewportResource>();
+        let viewport = world.resource::<ViewportResource>();
         let device = render_device.wgpu_device();
 
         renderer.with_primitives(|backend, primitives| {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -92,7 +92,7 @@ pub fn process_input(
     for ev in events.keyboard_input.iter() {
         if let Some(code) = ev.key_code {
             use keyboard::Event::*;
-            let modifiers = compute_modifiers(&*input_map);
+            let modifiers = compute_modifiers(&input_map);
             let event = match code {
                 KeyCode::LControl
                 | KeyCode::RControl

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -5,6 +5,8 @@ use bevy_ecs::{
     system::{Res, ResMut, Resource, SystemParam},
 };
 use bevy_input::keyboard::KeyCode;
+#[cfg(feature = "touch")]
+use bevy_input::touch::TouchInput;
 use bevy_input::{
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseWheel},
@@ -25,6 +27,8 @@ pub struct InputEvents<'w, 's> {
     mouse_wheel: EventReader<'w, 's, MouseWheel>,
     received_character: EventReader<'w, 's, ReceivedCharacter>,
     keyboard_input: EventReader<'w, 's, KeyboardInput>,
+    #[cfg(feature = "touch")]
+    touch_input: EventReader<'w, 's, TouchInput>,
 }
 
 fn compute_modifiers(input_map: &Input<KeyCode>) -> keyboard::Modifiers {
@@ -116,5 +120,10 @@ pub fn process_input(
 
             event_queue.push(IcedEvent::Keyboard(event));
         }
+    }
+
+    #[cfg(feature = "touch")]
+    for ev in events.touch_input.iter() {
+        event_queue.push(IcedEvent::Touch(conversions::touch_event(ev)));
     }
 }


### PR DESCRIPTION
For now, it's possible to use `bevy_iced` on the mobile platform as touch is working. I have tested it in my game.

Unfortunately `iced` doesn't support mobile platforms for now, and as a result, there is a workaround with `cursor_position`, but it works pretty well.

Please take a look.