### PR TITLE
Fix touch and wasm texture format error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,9 @@ impl IcedProps {
             .get_resource::<RenderDevice>()
             .unwrap()
             .wgpu_device();
+        #[cfg(target_arch = "wasm32")]
+        let format = wgpu::TextureFormat::Rgba8UnormSrgb;
+        #[cfg(not(target_arch = "wasm32"))]
         let format = wgpu::TextureFormat::Bgra8UnormSrgb;
 
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,14 @@ impl<'w, 's, M: Event> IcedContext<'w, 's, M> {
                     x: x * bounds.width / window.width(),
                     y: (window.height() - y) * bounds.height / window.height(),
                 })
-                .or_else(|| process_touch_input(self))
+                .or_else(|| {
+                    process_touch_input(self).map(|iced_native::Point { x, y }| {
+                        iced_native::Point {
+                            x: x * bounds.width / window.width(),
+                            y: y * bounds.height / window.height(),
+                        }
+                    })
+                })
                 .unwrap_or(iced_native::Point::ORIGIN)
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,19 +237,18 @@ impl<'w, 's, M: Event> IcedContext<'w, 's, M> {
         let cursor_position = {
             let window = self.windows.single();
 
-            window
-                .cursor_position()
-                .map(|Vec2 { x, y }| iced_native::Point {
+            process_touch_input(self)
+                .map(|iced_native::Point { x, y }| iced_native::Point {
                     x: x * bounds.width / window.width(),
-                    y: (window.height() - y) * bounds.height / window.height(),
+                    y: y * bounds.height / window.height(),
                 })
                 .or_else(|| {
-                    process_touch_input(self).map(|iced_native::Point { x, y }| {
-                        iced_native::Point {
+                    window
+                        .cursor_position()
+                        .map(|Vec2 { x, y }| iced_native::Point {
                             x: x * bounds.width / window.width(),
-                            y: y * bounds.height / window.height(),
-                        }
-                    })
+                            y: (window.height() - y) * bounds.height / window.height(),
+                        })
                 })
                 .unwrap_or(iced_native::Point::ORIGIN)
         };


### PR DESCRIPTION
This may fix #15, I don't have the means to test on ios, but it works for the web and windows touchscreen device. It should also fix #9, with the workaround.

I implemented the fix for #9 by @nikolajevs86, so it now works on the web.

Then I added some missing scaling for the touch input, so now the touch input works as expected.

I also changed the order of mouse input and touch input, because I notice that when you use a windows touchscreen device, the touch would register at the mouse pos, if the mouse was inside the window.